### PR TITLE
fix(gemspec): correct required Ruby version to >= 3.4.7 for dependabot

### DIFF
--- a/erb-processor.gemspec
+++ b/erb-processor.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   END_OF_DESCRIPTION
   spec.homepage = "https://github.com/cbroult/erb-processor"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 3.4.8"
+  spec.required_ruby_version = ">= 3.4.7"
 
   spec.metadata["allowed_push_host"] = "https://rubygems.org"
   spec.metadata["homepage_uri"] = spec.homepage


### PR DESCRIPTION
That is to correct the following message:

Dependabot does not support your ruby version

Dependabot detected the following ruby requirement for your project: '>= 3.4.8'.

Currently, the following ruby versions are supported in Dependabot: 1.8.7, 1.9.3, 2.0.0, 2.1.10, 2.2.10, 2.3.8, 2.4.10, 2.5.9, 2.6.9, 2.7.6, 3.0.6, 3.1.6, 3.2.8, 3.3.8, 3.4.7.