### PR TITLE
fix(rake): correct branch existence check in `branch` task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -58,7 +58,7 @@ namespace :upgrade do
   desc "Create a branch for the upgrade"
   task branch: :environment do
     sh "git checkout main"
-    sh "git branch -D upgrade/gems" if `git branch --list upgrade/gems`.any?
+    sh "git branch -D upgrade/gems" if `git branch --list upgrade/gems`.chomp.empty?
     sh "git pull"
     sh "git checkout -b upgrade/gems"
   end


### PR DESCRIPTION
- Updated existence check for `upgrade/gems` branch to handle `.chomp.empty?` logic.