### PR TITLE
Add required gems for compatibility with Ruby 4.0.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,7 @@ gem "guard-rubocop"
 gem "guard-yard"
 gem "juwelier"
 gem "rack"
+gem "rackup"
 gem "rdoc"
 gem "rspec-core"
 gem "rspec-expectations"
@@ -38,3 +39,6 @@ gem "shoulda"
 gem "simplecov"
 gem "syslog" unless Gem.win_platform?
 gem "wdm" if Gem.win_platform?
+gem "webrick"
+
+gem "ostruct", "~> 0.6.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -206,6 +206,7 @@ GEM
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 4)
+    ostruct (0.6.3)
     parallel (1.27.0)
     parser (3.3.10.1)
       ast (~> 2.4.1)
@@ -232,6 +233,8 @@ GEM
     racc (1.8.1)
     racc (1.8.1-java)
     rack (3.2.4)
+    rackup (2.3.1)
+      rack (>= 3)
     rainbow (3.1.1)
     rake (13.3.1)
     rb-fsevent (0.11.2)
@@ -335,6 +338,7 @@ GEM
       unicode-emoji (~> 4.1)
     unicode-emoji (4.2.0)
     uri (1.1.1)
+    webrick (1.9.2)
     yard (0.9.38)
 
 PLATFORMS
@@ -356,7 +360,9 @@ DEPENDENCIES
   guard-rubocop
   guard-yard
   juwelier
+  ostruct (~> 0.6.3)
   rack
+  rackup
   rake
   rdoc
   rspec
@@ -373,6 +379,7 @@ DEPENDENCIES
   shoulda
   simplecov
   syslog
+  webrick
 
 BUNDLED WITH
   4.0.4


### PR DESCRIPTION
Added `rackup`, `webrick`, and `ostruct` gems to the Gemfile to ensure compatibility with Ruby 4.0.1. Updated the `Gemfile.lock` accordingly.